### PR TITLE
new context to support messages or terms with leading indentation

### DIFF
--- a/Src/Fluent.sublime-syntax
+++ b/Src/Fluent.sublime-syntax
@@ -14,40 +14,61 @@ contexts:
   # Fluent's grammar is quite strict about where comments can be placed, but we allow them
   # almost everywhere, since otherwise we're not able to test our syntax definition.
   prototype:
+  - match: ^(?=#)
+    push: comments
+
+  comments:
   # Order matters.
-  - match: ^(###)([^ \n]?)(.*\n?)
+  - match: (###)([^ \n]?)(.*\n?)
     captures:
       1: comment.line.number-sign.resource.fluent punctuation.definition.comment.fluent
       2: invalid.illegal.space-required.fluent
       3: comment.line.number-sign.resource.fluent
-  - match: ^(##)([^ \n]?)(.*\n?)
+    pop: true
+  - match: (##)([^ \n]?)(.*\n?)
     captures:
       1: comment.line.number-sign.group.fluent punctuation.definition.comment.fluent
       2: invalid.illegal.space-required.fluent
       3: comment.line.number-sign.group.fluent
-  - match: ^(#)([^ \n^]?)(.*\n?) # '^' is allowed since it is used in Sublime syntax tests.
+    pop: true
+  - match: (#)([^ \n^]?)(.*\n?) # '^' is allowed since it is used in Sublime syntax tests.
     captures:
       1: comment.line.number-sign.fluent punctuation.definition.comment.fluent
       2: invalid.illegal.space-required.fluent
       3: comment.line.number-sign.fluent
+    pop: true
 
   main:
-  - include: messages
-  - include: terms
+  - match: '{{new_entry_start}}'
+    push: messages-or-terms
   - match: (.).*
     captures:
       1: invalid.illegal.fluent
+
+  messages-or-terms:
+  - include: messages
+  - include: terms
+  - match: ''
+    pop: true
+
+  messages-or-terms-allow-indentation:
+  - match: ^\s*(?=-?{{identifier}}\s*=)
+    set: messages-or-terms
+    embed: messages-or-terms
+    escape: ^(?=\s*(?:-?{{identifier}}\s*=|#))
+  - match: ^(?=\s*#)
+    push: comments
 
   #
   # Messages, terms, and their attributes.
   #
   messages:
-  - match: ^({{identifier}}) *(=) *
+  - match: ({{identifier}}) *(=) *
     captures:
       1: entity.name.message.fluent
       2: keyword.operator.assignment.fluent
     push: [message-contents, pattern]
-  - match: ^({{identifier}}) *(?:(.)(.*))?
+  - match: ({{identifier}}) *(?:(.)(.*))?
     captures:
       1: entity.name.message.fluent
       2: invalid.illegal.fluent
@@ -55,12 +76,12 @@ contexts:
     push: [message-contents, illegal-pattern]
 
   terms:
-  - match: ^(-(?:{{identifier}})?) *(=) *
+  - match: (-(?:{{identifier}})?) *(=) *
     captures:
       1: entity.name.term.fluent
       2: keyword.operator.assignment.fluent
     push: [term-contents, pattern]
-  - match: ^(-(?:{{identifier}})?) *(?:(.)(.*))?
+  - match: (-(?:{{identifier}})?) *(?:(.)(.*))?
     captures:
       1: entity.name.term.fluent
       2: invalid.illegal.fluent
@@ -300,7 +321,7 @@ contexts:
 
   argument-colon:
   - match: ':'
-    scope: punctuation.separator.fluent
+    scope: punctuation.separator.argument.value.fluent
     set: named-argument-value
 
   closing-paren:
@@ -313,10 +334,10 @@ contexts:
   - match: ({{identifier}}) *(:) # Named argument.
     captures:
       1: variable.parameter.fluent
-      2: punctuation.separator.fluent
+      2: punctuation.separator.argument.value.fluent
     set: named-argument-value
   - match: ',' # Multiple commas in a row.
-    scope: punctuation.separator.fluent
+    scope: punctuation.separator.argument.fluent
   - match: \}
     scope: invalid.illegal.fluent
   - include: expression-tabs
@@ -325,7 +346,7 @@ contexts:
 
   positional-argument-comma:
   - match: ','
-    scope: punctuation.separator.fluent
+    scope: punctuation.separator.argument.fluent
     set: positional-argument-value
   - include: closing-paren
   - include: argument-colon # There was a line break between an argument name and a colon.
@@ -337,7 +358,7 @@ contexts:
   named-argument-value:
   - include: closing-paren # Named argument without value.
   - match: ',' # Named argument without value.
-    scope: punctuation.separator.fluent
+    scope: punctuation.separator.argument.fluent
     set: named-argument-key
   - match: '[:}]'
     scope: invalid.illegal.fluent
@@ -347,7 +368,7 @@ contexts:
 
   named-argument-comma:
   - match: ','
-    scope: punctuation.separator.fluent
+    scope: punctuation.separator.argument.fluent
     set: named-argument-key
   - include: closing-paren
   - include: expression-tabs

--- a/Src/FluentInJsTest.sublime-syntax
+++ b/Src/FluentInJsTest.sublime-syntax
@@ -1,0 +1,19 @@
+%YAML 1.2
+---
+name: Fluent in JS Test
+hidden: true
+scope: source.fluentjstest
+contexts:
+  main:
+    - match: ''
+      push: scope:source.js
+      with_prototype:
+        - match: '(ftl)(`)'
+          captures:
+            1: variable.function.tagged-template.js
+            2: string.quoted.other.js punctuation.definition.string.begin.js
+          embed: scope:source.fluent#messages-or-terms-allow-indentation
+          embed_scope: meta.string.js
+          escape: '`'
+          escape_captures:
+            0: string.quoted.other.js punctuation.definition.string.end.js

--- a/Tests/syntax_test_ftl_in_js
+++ b/Tests/syntax_test_ftl_in_js
@@ -1,0 +1,170 @@
+# SYNTAX TEST "Packages/Fluent/Src/FluentInJsTest.sublime-syntax"
+import ftl from "@fluent/dedent";
+
+let messages = ftl`
+    hello = Hello, world!
+#   ^^^^^ entity.name.message
+#         ^ keyword.operator.assignment
+#           ^^^^^^^^^^^^^^ string.unquoted
+    welcome = Welcome, {$userName}!
+#   ^^^^^^^ entity.name.message
+#           ^ keyword.operator.assignment
+#             ^^^^^^^^^ string.unquoted
+#                      ^^^^^^^^^^^ meta.interpolation
+#                      ^ punctuation.section.interpolation.begin
+#                       ^ punctuation.definition.variable
+#                       ^^^^^^^^^ variable.other
+#                                ^ punctuation.section.interpolation.end
+#                                 ^ string.unquoted - meta.interpolation
+
+    shared-schedule =
+        { $other_user_name } has shared { $other_user_gender ->
+            [male] his
+            [female] her
+           *[other] their
+        } schedule with you.
+
+    # ✅ All variants are language-specific. The [0] variant adds
+#   ^ punctuation.definition.comment
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line
+    # flavor to the translation. The default variant still works
+    # for all values of the selector, even if "0 new notifications"
+    # sounds a bit off.
+    new-notifications =
+        { $num ->
+            [0] No new notifications.
+            [one] New notification.
+           *[other] { $num } new notifications.
+        }
+
+    # ✅ Separate messages which serve different purposes.
+    items-select = Select items
+    # ✅ The default variant works for all values of the selector.
+    items-selected =
+        { $num ->
+            [one] One item selected.
+           *[other] { $num } items selected.
+        }
+
+    # Simple string
+    title = About Localization
+
+    # Multiline string: press Shift + Enter to insert new line
+    feedbackUninstallCopy =
+        Your participation in Firefox Test Pilot means
+        a lot! Please check out our other experiments,
+        and stay tuned for more to come.
+
+    # Attributes: in original string
+    emailOptInInput =
+        .placeholder = email goes here :)
+
+    # Attributes: access keys
+    file-menu =
+        .label = File
+        .accesskey = F
+
+    other-file-menu =
+        .aria-label = {file-menu.label}
+        .accesskey = {file-menu.accesskey}
+
+    # Value and an attribute
+    shotIndexNoExpirationSymbol = ∞
+        .title = This shot does not expire
+
+    # Plurals
+    delete-all-message =
+        { $num ->
+            [one] Delete this download?
+           *[other] Delete { $num } downloads?
+        }
+
+    # Plurals with custom values
+    delete-all-message-special-cases =
+        { $num ->
+            [1] Delete this download?
+            [2] Delete this pair of downloads?
+            [12] Delete this dozen of downloads?
+           *[other] Delete { $num } downloads?
+        }
+
+    # NUMBER Built-in function
+    today-is = Today is { DATETIME($date, month: "long", year: "numeric", day: "numeric") }
+
+    # Soft Launch
+    default-content-process-count =
+        .label = { $num } (default)
+
+    # PLATFORM() selector
+    platform =
+        { PLATFORM() ->
+            [win] Options
+           *[other] Preferences
+        }
+
+    # NUMBER() selector
+    number =
+        { NUMBER($var, type: "ordinal") ->
+            [1] first
+            [one] { $var }st
+           *[other] { $var }nd
+        }
+
+    # PLATFORM() selector in attribute
+    platform-attribute =
+        .title = { PLATFORM() ->
+            [win] Options
+           *[other] Preferences
+        }
+
+    # Double selector in attributes
+    download-choose-folder =
+        .label =
+            { PLATFORM() ->
+                [macos] Choose…
+               *[other] Browse…
+            }
+        .accesskey =
+            { PLATFORM() ->
+                [macos] e
+               *[other] o
+            }
+
+    # Multiple selectors
+    selector-multi =
+       There { $num ->
+           [one] is one email
+          *[other] are many emails
+       } for { $gender ->
+          *[masculine] him
+           [feminine] her
+       }
+
+    # Term
+    -term = Term
+
+    # TermReference
+    term-reference = Term { -term } Reference
+
+    # StringExpression
+    string-expression = { "" }
+
+    # NumberExpression
+    number-expression = { 5 }
+
+    # MessageReference with attribute (was: AttributeExpression)
+    attribute-expression = { my_id.title }
+
+    # Nested selectors
+    selector-nested =
+       { $gender ->
+          *[masculine] { $num ->
+               [one] There is one email for her
+              *[other] There are many emails for her
+           }
+           [feminine] { $num ->
+               [one] There is one email for him
+              *[other] There are many emails for him
+           }
+       }
+    `


### PR DESCRIPTION
Hi, thanks for your hard work on this package, it's really useful.

I'm using fluent.js, and it has support for [stripping leading indentation from the text before it is parsed as a fluent resource as part of `@fluent/dedent`](https://github.com/projectfluent/fluent.js/tree/b504168202f179ec9a756c40a4584f1797f534cf/fluent-dedent#how-to-use), so that the JS can still be "pretty". Unfortunately, the syntax definition currently marks almost everything as invalid in this case. (I'm using https://packagecontrol.io/packages/JSCustom to highlight the fluent embedded in the JS.)

This PR adds a new context called `messages-or-terms-allow-indentation` to the syntax definition, which can be targeted when embedding the syntax using JSCustom, which adds `\s*` after the `^` anchor to allow it to be highlighted properly. I also had to tweak a couple of the other contexts a bit so that I could reuse everything easily. The new context isn't referenced anywhere else in the syntax, so the behavior hasn't changed when using this syntax definition directly, and all the existing syntax tests still pass. I added a dummy, hidden syntax to help test my changes, which kinda emulates what JSCustom does.

It's a little tricky to add lots of test assertions due to the way a comment is only allowed in certain places, so for my test file I added quite a few examples with no assertions, the idea being that they can be visually inspected at a glance.

I also tweaked a couple of the punctuation scopes to be slightly more specific, to match some syntax definitions which ship with ST, and thus look prettier in my color scheme.

Please let me know what you think about all these tweaks and thanks for your consideration :)

A screenshot of how the new syntax test file looks with my color scheme (an enhanced version of Monokai):
![image](https://user-images.githubusercontent.com/11882719/84315683-b59fed80-ab72-11ea-96bc-191fda3d893d.png)
